### PR TITLE
Fix bump-wgc no-op guard for identical versions

### DIFF
--- a/.github/workflows/bump-wgc.yml
+++ b/.github/workflows/bump-wgc.yml
@@ -23,7 +23,7 @@ jobs:
           set -euo pipefail
           V="${{ github.event.client_payload.version || inputs.version }}"
           [ -z "$V" ] && V="$(npm view wgc version)"
-          CUR="$(grep -oE 'wgc-[0-9]+\.[0-9]+\.[0-9]+\.tgz' Formula/wgc.rb | grep -oE '[0-9.]+' | head -1)"
+          CUR="$(grep -oE 'wgc-[0-9]+\.[0-9]+\.[0-9]+\.tgz' Formula/wgc.rb | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
           if [ "$V" = "$CUR" ]; then echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0; fi
           URL="https://registry.npmjs.org/wgc/-/wgc-${V}.tgz"
           SHA="$(curl -fsSL "$URL" | shasum -a 256 | cut -d' ' -f1)"
@@ -43,6 +43,10 @@ jobs:
         if: steps.v.outputs.changed == 'true'
         run: |
           set -euo pipefail
+          if git diff --quiet; then
+            echo "Formula already at wgc ${{ steps.v.outputs.v }}; nothing to commit."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "wgc ${{ steps.v.outputs.v }}"


### PR DESCRIPTION
The manual `workflow_dispatch` run of **Bump wgc** with the already-current version (`0.123.0`) failed at *Commit and push* with `nothing to commit, working tree clean` (exit 1).

## Cause
The "already at this version" guard never matched. `CUR` was extracted with `grep -oE '[0-9.]+'` against `wgc-0.123.0.tgz`, which greedily captures the trailing dot too — yielding `0.123.0.` instead of `0.123.0`. So `[ "$V" = "$CUR" ]` was always false, the bump proceeded, `sed` was a no-op (URL/sha already correct), and `git commit` then failed on a clean tree.

## Fix
- Tighten the `CUR` regex to `[0-9]+\.[0-9]+\.[0-9]+` so it matches the exact version with no trailing dot — the guard now short-circuits correctly on identical versions.
- Belt-and-braces: the commit step now `git diff --quiet`-checks and exits 0 if there's nothing to commit, so a no-op rewrite can never fail the job again.