### PR TITLE
Fill the whole version gap when bumping wgc

### DIFF
--- a/.github/workflows/bump-wgc.yml
+++ b/.github/workflows/bump-wgc.yml
@@ -24,33 +24,50 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.v.outputs.changed }}
-      version: ${{ steps.v.outputs.v }}
-      url: ${{ steps.v.outputs.url }}
-      sha: ${{ steps.v.outputs.sha }}
-      tag: ${{ steps.v.outputs.tag }}
+      meta: ${{ steps.v.outputs.meta }}
+      matrix: ${{ steps.v.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve version, url, sha256
+      - name: Resolve the missing version range
         id: v
         run: |
           set -euo pipefail
-          V="${{ github.event.client_payload.version || inputs.version }}"
-          [ -z "$V" ] && V="$(npm view wgc version)"
           CUR="$(grep -oE 'wgc-[0-9]+\.[0-9]+\.[0-9]+\.tgz' Formula/wgc.rb | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-          if [ "$V" = "$CUR" ]; then
-            echo "Formula already at wgc ${V}; nothing to do."
+          T="${{ github.event.client_payload.version || inputs.version }}"
+          [ -z "$T" ] && T="$(npm view wgc version)"
+
+          all="$(npm view wgc versions --json | jq -r '.[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')"
+          missing="$(printf '%s\n%s\n' "$all" "$CUR" | sort -V -u \
+                    | sed -n "/^${CUR//./\\.}\$/,/^${T//./\\.}\$/p" | grep -vx "$CUR" || true)"
+
+          if [ -z "$missing" ]; then
+            echo "Formula already at wgc ${CUR}; target ${T}; nothing to do."
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          URL="https://registry.npmjs.org/wgc/-/wgc-${V}.tgz"
-          SHA="$(curl -fsSL "$URL" | shasum -a 256 | cut -d' ' -f1)"
+          echo "Filling gap from ${CUR} -> ${T}:"
+          echo "$missing"
+
+          meta='{}'
+          include='[]'
+          while IFS= read -r V; do
+            [ -z "$V" ] && continue
+            URL="https://registry.npmjs.org/wgc/-/wgc-${V}.tgz"
+            SHA="$(curl -fsSL "$URL" | shasum -a 256 | cut -d' ' -f1)"
+            TAG="wgc-${V}"
+            meta="$(jq -c --arg v "$V" --arg url "$URL" --arg sha "$SHA" --arg tag "$TAG" \
+              '.[$v]={url:$url,sha:$sha,tag:$tag}' <<<"$meta")"
+            for OS in macos-14 ubuntu-latest; do
+              include="$(jq -c --arg v "$V" --arg os "$OS" --arg url "$URL" --arg sha "$SHA" --arg tag "$TAG" \
+                '. += [{version:$v,os:$os,url:$url,sha:$sha,tag:$tag}]' <<<"$include")"
+            done
+          done <<< "$missing"
+
           {
-            echo "v=$V"
-            echo "url=$URL"
-            echo "sha=$SHA"
-            echo "tag=wgc-$V"
             echo "changed=true"
+            echo "meta=$meta"
+            echo "matrix=$(jq -cn --argjson include "$include" '{include:$include}')"
           } >> "$GITHUB_OUTPUT"
 
   bottle:
@@ -58,8 +75,7 @@ jobs:
     if: needs.resolve.outputs.changed == 'true'
     strategy:
       fail-fast: true
-      matrix:
-        os: [macos-14, ubuntu-latest]
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: Homebrew/actions/setup-homebrew@main
@@ -79,8 +95,8 @@ jobs:
           mkdir -p "$(dirname "$dest")"
           ln -s "$GITHUB_WORKSPACE/tap-src" "$dest"
           f="$dest/Formula/wgc.rb"
-          perl -0pi -e 's|url "https://registry\.npmjs\.org/wgc/-/wgc-[0-9.]+\.tgz"|url "${{ needs.resolve.outputs.url }}"|' "$f"
-          perl -0pi -e 's|sha256 "[a-f0-9]{64}"|sha256 "${{ needs.resolve.outputs.sha }}"|' "$f"
+          perl -0pi -e 's|url "https://registry\.npmjs\.org/wgc/-/wgc-[0-9.]+\.tgz"|url "${{ matrix.url }}"|' "$f"
+          perl -0pi -e 's|sha256 "[a-f0-9]{64}"|sha256 "${{ matrix.sha }}"|' "$f"
           echo "formula=${owner}/${name}/wgc" >> "$GITHUB_OUTPUT"
 
       - name: Build bottle
@@ -88,13 +104,13 @@ jobs:
           set -euo pipefail
           brew install --build-bottle "${{ steps.tap.outputs.formula }}"
           brew bottle --json --no-rebuild \
-            --root-url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ needs.resolve.outputs.tag }}" \
+            --root-url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ matrix.tag }}" \
             "${{ steps.tap.outputs.formula }}"
 
       - name: Upload bottle metadata for the publish job
         uses: actions/upload-artifact@v4
         with:
-          name: bottle-json-${{ matrix.os }}
+          name: bottle-json-${{ matrix.version }}-${{ matrix.os }}
           path: tap-src/*.bottle.json
 
       - name: Upload bottle tarball to the release
@@ -103,10 +119,10 @@ jobs:
         run: |
           set -euo pipefail
           cd tap-src
-          tag="${{ needs.resolve.outputs.tag }}"
+          tag="${{ matrix.tag }}"
           gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
             || gh release create "$tag" --repo "$GITHUB_REPOSITORY" \
-                 --title "$tag" --notes "Homebrew bottles for wgc ${{ needs.resolve.outputs.version }}" \
+                 --title "$tag" --notes "Homebrew bottles for wgc ${{ matrix.version }}" \
             || gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null
           # The bottle DSL references a single-dash filename; brew writes double.
           for f in *--*.bottle.tar.gz; do
@@ -129,11 +145,11 @@ jobs:
         with:
           path: bottle-json
           pattern: bottle-json-*
-          merge-multiple: true
 
-      - name: Link repo as a tap, apply version, merge bottle block
+      - name: Link repo as a tap and commit one version at a time
         run: |
           set -euo pipefail
+          META='${{ needs.resolve.outputs.meta }}'
           owner="${GITHUB_REPOSITORY%%/*}"
           name="${GITHUB_REPOSITORY#*/homebrew-}"
           dest="$(brew --repository)/Library/Taps/${owner}/homebrew-${name}"
@@ -141,19 +157,19 @@ jobs:
           mkdir -p "$(dirname "$dest")"
           ln -s "$GITHUB_WORKSPACE/tap-src" "$dest"
           f="$dest/Formula/wgc.rb"
-          perl -0pi -e 's|url "https://registry\.npmjs\.org/wgc/-/wgc-[0-9.]+\.tgz"|url "${{ needs.resolve.outputs.url }}"|' "$f"
-          perl -0pi -e 's|sha256 "[a-f0-9]{64}"|sha256 "${{ needs.resolve.outputs.sha }}"|' "$f"
-          brew bottle --merge --write --no-commit "$GITHUB_WORKSPACE/bottle-json"/*.bottle.json
 
-      - name: Commit and push
-        run: |
-          set -euo pipefail
-          cd tap-src
-          if git diff --quiet; then
-            echo "No formula changes to commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "wgc ${{ needs.resolve.outputs.version }}"
-          git push
+          git -C tap-src config user.name "github-actions[bot]"
+          git -C tap-src config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          for V in $(jq -r 'keys[]' <<<"$META" | sort -V); do
+            url="$(jq -r --arg v "$V" '.[$v].url' <<<"$META")"
+            sha="$(jq -r --arg v "$V" '.[$v].sha' <<<"$META")"
+            perl -0pi -e "s|url \"https://registry\\.npmjs\\.org/wgc/-/wgc-[0-9.]+\\.tgz\"|url \"$url\"|" "$f"
+            perl -0pi -e "s|sha256 \"[a-f0-9]{64}\"|sha256 \"$sha\"|" "$f"
+            brew bottle --merge --write --no-commit \
+              "$GITHUB_WORKSPACE/bottle-json/bottle-json-${V}-"*/*.bottle.json
+            git -C tap-src commit -am "wgc $V"
+            echo "Committed wgc $V"
+          done
+
+          git -C tap-src push


### PR DESCRIPTION
## What

`bump-wgc.yml` previously bumped the formula to exactly the dispatched target version. When several wgc versions are released close together, every version between the tap's current formula version and the target got skipped — no formula commit, no bottle.

This makes the tap derive the gap itself and build/publish the whole range, oldest-first, each with its own bottle.

## How

- **resolve** — reads `CUR` from `Formula/wgc.rb`, resolves `T` (`client_payload.version` || `inputs.version` || `npm view wgc version`), and computes the ordered `MISSING` list of all stable `x.y.z` versions strictly `> CUR` and `<= T` via semver `sort -V`. Computes url + sha256 per version once. Emits `changed`, a `meta` JSON map, and a build `matrix` (MISSING × [macos-14, ubuntu-latest]).
- **bottle** — driven by `fromJSON(needs.resolve.outputs.matrix)`, parameterised per matrix entry. Ensures a per-version `wgc-<version>` release exists, uploads that version's bottle tarball, and uploads bottle JSON as `bottle-json-<version>-<os>`.
- **publish** — downloads all bottle JSON artifacts, then loops over `MISSING` ascending: perl-edits the formula to each version's url/sha, merges that version's bottle JSONs, and commits `wgc <version>`. Pushes once at the end.

Concurrency group (`bump-wgc`, `cancel-in-progress: false`), the `workflow_dispatch` version input, and the npm-tarball / brew bottle mechanics are unchanged. The 24h cooldown stays enforced cosmo-side, so any version `<= T` is safe to build.

## Testing

Dry-ran the resolve/publish shell against the live npm version list (no brew/releases/push):
- Rolled-back `CUR=0.122.0`, target `0.125.0` → `MISSING = 0.123.0, 0.124.0, 0.125.0`; matrix = 6 entries; publish order ascending.
- No-op case (`CUR == T`) → `changed=false`.
- Single-version gap → just the target.
- YAML parses.